### PR TITLE
Fix out-of-tree build

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -8,4 +8,4 @@ bin_PROGRAMS = irecovery
 irecovery_SOURCES = irecovery.c
 irecovery_CFLAGS = $(AM_CFLAGS)
 irecovery_LDFLAGS = $(AM_LDFLAGS)
-irecovery_LDADD = $(top_srcdir)/src/libirecovery.la
+irecovery_LDADD = ../src/libirecovery.la


### PR DESCRIPTION
Now this sequence works properly:

```
NOCONFIGURE=1 ./autogen.sh
mkdir build && cd $_
../configure
make
```
