### PR TITLE
Fixing issue on OS X which causes the inability to connect to a device.

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -825,9 +825,7 @@ IRECV_API irecv_error_t irecv_open_with_ecid(irecv_client_t* pclient, unsigned l
 
 				if ((client->mode != IRECV_K_DFU_MODE) && (client->mode != IRECV_K_WTF_MODE)) {
 					error = irecv_usb_set_interface(client, 0, 0);
-					if (client->mode > IRECV_K_RECOVERY_MODE_2) {
 						error = irecv_usb_set_interface(client, 1, 1);
-					}
 				} else {
 					error = irecv_usb_set_interface(client, 0, 0);
 				}


### PR DESCRIPTION
Without the fix it will loop at:

Attempting to connect...
opening device 05ac:1281...
 Setting to configuration 1
Setting to interface 0:0
libusb: error [get_endpoints] error getting pipe information for pipe 1: unknown error (0xe0004061)
libusb: error [darwin_set_interface_altsetting] could not build endpoint table
Attempting to connect...
opening device 05ac:1281...
 Setting to configuration 1
Setting to interface 0:0
libusb: error [get_endpoints] error getting pipe information for pipe 1: unknown error (0xe0004061)
libusb: error [darwin_set_interface_altsetting] could not build endpoint table
Attempting to connect...
opening device 05ac:1281...
 Setting to configuration 1
Setting to interface 0:0
libusb: error [get_endpoints] error getting pipe information for pipe 1: unknown error (0xe0004061)
libusb: error [darwin_set_interface_altsetting] could not build endpoint table
Attempting to connect...
opening device 05ac:1281...
 Setting to configuration 1
Setting to interface 0:0
libusb: error [get_endpoints] error getting pipe information for pipe 1: unknown error (0xe0004061)
libusb: error [darwin_set_interface_altsetting] could not build endpoint table
