### PR TITLE
Fixed crash in irecv_open_with_ecid when multiple USB device connected

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -1409,6 +1409,7 @@ IRECV_API irecv_error_t irecv_open_with_ecid(irecv_client_t* pclient, unsigned l
 				libusb_free_device_list(usb_device_list, 1);
 
 				ret = IRECV_E_SUCCESS;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
when multiple usb device are connected, irecv_open_with_ecid with libusb would keep iterating the for loop even when a device was found.
Another problem is that that since `libusb_free_device_list` alread freed `usb_device_list` the for loop keep iterating over freed elements, resulting in a crash.