### PR TITLE
Add MacBook Pro 2020 13" four thunderbolt

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -245,6 +245,7 @@ static struct irecv_device irecv_devices[] = {
 	{ "iBridge2,10", "j213ap",   0x18, 0x8012, "Apple T2 MacBookPro15,4 (j213)" },
 	{ "iBridge2,12", "j140aap",  0x37, 0x8012, "Apple T2 MacBookAir8,2 (j140a)" },
 	{ "iBridge2,14", "j152f",    0x3A, 0x8012, "Apple T2 MacBookPro16,1 (j152f)" },
+	{ "iBridge2,16", "j214kap",    ??, ??, "Apple T2 MacBookPro16,2 (j214kap)" },
 	{ NULL,          NULL,         -1,     -1, NULL }
 };
 

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -245,7 +245,7 @@ static struct irecv_device irecv_devices[] = {
 	{ "iBridge2,10", "j213ap",   0x18, 0x8012, "Apple T2 MacBookPro15,4 (j213)" },
 	{ "iBridge2,12", "j140aap",  0x37, 0x8012, "Apple T2 MacBookAir8,2 (j140a)" },
 	{ "iBridge2,14", "j152f",    0x3A, 0x8012, "Apple T2 MacBookPro16,1 (j152f)" },
-	{ "iBridge2,16", "j214kap",    ??, ??, "Apple T2 MacBookPro16,2 (j214kap)" },
+	{ "iBridge2,16", "j214kap",  0x3E, 0x8012, "Apple T2 MacBookPro16,2 (j214kap)" },
 	{ NULL,          NULL,         -1,     -1, NULL }
 };
 

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -245,7 +245,7 @@ static struct irecv_device irecv_devices[] = {
 	{ "iBridge2,10", "j213ap",   0x18, 0x8012, "Apple T2 MacBookPro15,4 (j213)" },
 	{ "iBridge2,12", "j140aap",  0x37, 0x8012, "Apple T2 MacBookAir8,2 (j140a)" },
 	{ "iBridge2,14", "j152f",    0x3A, 0x8012, "Apple T2 MacBookPro16,1 (j152f)" },
-	{ "iBridge2,16", "j214kap",  0x3E, 0x8012, "Apple T2 MacBookPro16,2 (j214kap)" },
+	{ "iBridge2,16", "j214kap",  0x3E, 0x8012, "Apple T2 MacBookPro16,2 (j214k)" },
 	{ NULL,          NULL,         -1,     -1, NULL }
 };
 


### PR DESCRIPTION
Add MacBook Pro (13-inch, 2020, Four Thunderbolt 3 ports)

**IMPORTANT**: I don't know how to get those hex values, so I have put `??` in their place. Please tell me how I get them so I can add it for you. Terminal output: [Imgur](https://imgur.com/a/KY769pA)

if you need help, DM me on twitter. ([A_MrBenMitchell](https://twitter.com/A_MrBenMitchell))