### PR TITLE
Display device's product id and name when querying device info

### DIFF
--- a/tools/irecovery.c
+++ b/tools/irecovery.c
@@ -139,6 +139,7 @@ static void print_device_info(irecv_client_t client)
     if (modelinfo){
         printf("Name: %s\n", modelinfo->display_name);
         printf("Type: %s\n", modelinfo->product_type);
+				printf("BORD: %s\n", modelinfo->hardware_model);
     }
 	const struct irecv_device_info *devinfo = irecv_get_device_info(client);
 	if (devinfo) {

--- a/tools/irecovery.c
+++ b/tools/irecovery.c
@@ -134,13 +134,13 @@ static void print_hex(unsigned char *buf, size_t len)
 static void print_device_info(irecv_client_t client)
 {
 	int ret, mode;
-    irecv_device_t modelinfo = NULL;
-    irecv_devices_get_device_by_client(client, &modelinfo);
-    if (modelinfo){
-        printf("Name: %s\n", modelinfo->display_name);
-        printf("Type: %s\n", modelinfo->product_type);
-				printf("BORD: %s\n", modelinfo->hardware_model);
-    }
+		irecv_device_t modelinfo = NULL;
+		irecv_devices_get_device_by_client(client, &modelinfo);
+	if (modelinfo){
+		printf("NAME: %s\n", modelinfo->display_name);
+		printf("TYPE: %s\n", modelinfo->product_type);
+		printf("BORD: %s\n", modelinfo->hardware_model);
+	}
 	const struct irecv_device_info *devinfo = irecv_get_device_info(client);
 	if (devinfo) {
 		printf("CPID: 0x%04x\n", devinfo->cpid);

--- a/tools/irecovery.c
+++ b/tools/irecovery.c
@@ -134,6 +134,12 @@ static void print_hex(unsigned char *buf, size_t len)
 static void print_device_info(irecv_client_t client)
 {
 	int ret, mode;
+    irecv_device_t modelinfo = NULL;
+    irecv_devices_get_device_by_client(client, &modelinfo);
+    if (modelinfo){
+        printf("Name: %s\n", modelinfo->display_name);
+        printf("Type: %s\n", modelinfo->product_type);
+    }
 	const struct irecv_device_info *devinfo = irecv_get_device_info(client);
 	if (devinfo) {
 		printf("CPID: 0x%04x\n", devinfo->cpid);


### PR DESCRIPTION
**Example of new output:**
$ irecovery -q
Name: Mac mini (M1, 2020)
Type: Macmini9,1
CPID: 0x8103
CPRV: 0x11
BDID: 0x22
ECID: 0xxxxxxxxxxxxxxxxx
CPFM: 0x03
SCEP: 0x01
IBFL: 0x3c
SRTG: iBoot-5540.0.0.400.2
SRNM: N/A
IMEI: N/A
NONC: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
SNON: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
MODE: DFU

