### PR TITLE
Add the option to choose the b_request usb param when sending commands

### DIFF
--- a/include/libirecovery.h
+++ b/include/libirecovery.h
@@ -148,6 +148,7 @@ irecv_error_t irecv_event_unsubscribe(irecv_client_t client, irecv_event_type ty
 /* I/O */
 irecv_error_t irecv_send_file(irecv_client_t client, const char* filename, int dfu_notify_finished);
 irecv_error_t irecv_send_command(irecv_client_t client, const char* command);
+irecv_error_t irecv_send_command_breq(irecv_client_t client, const char* command, uint8_t b_request);
 irecv_error_t irecv_send_buffer(irecv_client_t client, unsigned char* buffer, unsigned long length, int dfu_notify_finished);
 irecv_error_t irecv_recv_buffer(irecv_client_t client, char* buffer, unsigned long length);
 


### PR DESCRIPTION
Hello !

This pull request goes hand in hand with the new one that i'm going to open on idevicerestore.

While reverse engineering the protocol (for educational purposes), i discovered that commands were sent using a b_req of 1. This PR adds the ability to supply a value for it if needed.