### PR TITLE
Fix racecondition in even handler shutdown

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -2381,6 +2381,7 @@ IRECV_API irecv_error_t irecv_device_event_unsubscribe(irecv_device_event_contex
 	if (num == 0) {
 #ifdef HAVE_IOKIT
 		if (iokit_runloop) {
+			while (!CFRunLoopIsWaiting(iokit_runloop)) usleep(420);
 			CFRunLoopStop(iokit_runloop);
 		}
 #endif


### PR DESCRIPTION
There is a racecondition when you call irecv_device_event_unsubscribe shortly after irecv_device_event_subscribe.
If the `_irecv_event_handler` thread didn't reach `CFRunLoopRun();` before `irecv_device_event_unsubscribe` calls `CFRunLoopStop()`, the call doesn't actually stop the runloop and then `irecv_device_event_unsubscribe` hangs forever at `thread_join(th_event_handler); `.

This patch makes sure that CFRunloop is actually idle, before calling `CFRunLoopStop`.