### PR TITLE
Add device IDs for macOS 12 Apple Silicon VMs

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -286,6 +286,9 @@ static struct irecv_device irecv_devices[] = {
 	{ "MacBookAir10,1", "j313ap",  0x26, 0x8103, "MacBook Air (M1, 2020)" },
 	{ "iMac21,1",       "j456ap",  0x28, 0x8103, "iMac 24-inch (M1, Two Ports, 2021)" },
 	{ "iMac21,2",       "j457ap",  0x2A, 0x8103, "iMac 24-inch (M1, Four Ports, 2021)" },
+	/* Apple Silicon VMs (supported by Virtualization.framework on macOS 12) */
+	{ "VirtualMac1,1",  "vma1ap",       0xF8, 0x8103, "Apple Virtual Machine 1 (VirtualMac1,1, unused)" },
+	{ "VirtualMac2,1",  "vma2macosap",  0x20, 0xFE00, "Apple Virtual Machine 1" },
 	/* Apple T2 Coprocessor */
 	{ "iBridge2,1",	 "j137ap",   0x0A, 0x8012, "Apple T2 iMacPro1,1 (j137)" },
 	{ "iBridge2,3",	 "j680ap",   0x0B, 0x8012, "Apple T2 MacBookPro15,1 (j680)" },


### PR DESCRIPTION
Adds device IDs for macOS 12's Apple Silicon VMs, as created in macOS 12 Virtualization.framework (https://developer.apple.com/documentation/virtualization/vzmachardwaremodel?language=objc)

Currently, macOS 12 beta 2 has device trees and support in Virtualization.framework for two different virtual machine types, VirtualMac1,1 and VirtualMac2,1. The first seems to be unused: only the VirtualMac2,1 variant is being signed.

See http://swcdn.apple.com/content/downloads/38/12/071-51840-A_R2JDKNM0LX/wqollynqs6j5006166tvw4rliu9htf7swu/BuildManifest.plist for the board IDs.

idevicerecovery can't recover the virtual machines through virtual DFU mode since it fails to send iBEC: https://gist.github.com/zhuowei/baabd6a3600eb1d59096fa056f3ab0d8 (Apple Configurator 2 is able to restore VMs over DFU, so the VM is working). Might as well add the device IDs anyway.