### PR TITLE
Win32: the device location is a string and cannot be converted to an integer

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -2207,7 +2207,13 @@ static void *_irecv_event_handler(void* data)
 					free(details);
 					continue;
 				}
-				uint32_t location = strtoul(p+1, NULL, 16);
+				uint32_t location = 0;
+				if ((p+1 == NULL) || strlen(p+1) < 4) {
+					debug("%s: ERROR: Driver location suffix too short\n", __func__);
+					free(details);
+					continue;
+				}
+				memcpy(&location, p+1, 4);
 				int found = 0;
 
 				FOREACH(struct irecv_usb_device_info *devinfo, &devices) {


### PR DESCRIPTION
I don't think you've read the registry data I sent you carefully.
There are the following entries in the registry.

77 line : "Driver"="{88bae032-5a81-49f0-bc3d-a4ff138216d6}\\9dlq"
365 line : "Driver"="{88bae032-5a81-49f0-bc3d-a4ff138216d6}\\9f3n"
608 line : "Driver"="{88bae032-5a81-49f0-bc3d-a4ff138216d6}\\9dw3"
800 line : "Driver"="{88bae032-5a81-49f0-bc3d-a4ff138216d6}\\9ckk"
more...

I copy its memory value directly to the integer, so we have a unique value.

[reg.rar.log](https://github.com/libimobiledevice/libirecovery/files/7401978/reg.rar.log)
#93 

