### PR TITLE
Introduce non-persistent setenvnp command

### DIFF
--- a/include/libirecovery.h
+++ b/include/libirecovery.h
@@ -156,6 +156,7 @@ irecv_error_t irecv_recv_buffer(irecv_client_t client, char* buffer, unsigned lo
 irecv_error_t irecv_saveenv(irecv_client_t client);
 irecv_error_t irecv_getenv(irecv_client_t client, const char* variable, char** value);
 irecv_error_t irecv_setenv(irecv_client_t client, const char* variable, const char* value);
+irecv_error_t irecv_setenv_np(irecv_client_t client, const char* variable, const char* value);
 irecv_error_t irecv_reboot(irecv_client_t client);
 irecv_error_t irecv_getret(irecv_client_t client, unsigned int* value);
 

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -3097,6 +3097,30 @@ IRECV_API irecv_error_t irecv_setenv(irecv_client_t client, const char* variable
 #endif
 }
 
+IRECV_API irecv_error_t irecv_setenv_np(irecv_client_t client, const char* variable, const char* value) {
+#ifdef USE_DUMMY
+	return IRECV_E_UNSUPPORTED;
+#else
+	char command[256];
+
+	if (check_context(client) != IRECV_E_SUCCESS)
+		return IRECV_E_NO_DEVICE;
+
+	if(variable == NULL || value == NULL) {
+		return IRECV_E_UNKNOWN_ERROR;
+	}
+
+	memset(command, '\0', sizeof(command));
+	snprintf(command, sizeof(command)-1, "setenvnp %s %s", variable, value);
+	irecv_error_t error = irecv_send_command_raw(client, command, 0);
+	if(error != IRECV_E_SUCCESS) {
+		return error;
+	}
+
+	return IRECV_E_SUCCESS;
+#endif
+}
+
 IRECV_API irecv_error_t irecv_reboot(irecv_client_t client) {
 #ifdef USE_DUMMY
 	return IRECV_E_UNSUPPORTED;


### PR DESCRIPTION
Modern macOS restore (M1) has a `setenvnp` for non-persistent in the DFU process.  This adds the needed API surface