### PR TITLE
Add new M2 Mac mini and M2 Pro Mac mini to device list.

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -328,6 +328,8 @@ static struct irecv_device irecv_devices[] = {
 	{ "Mac13,2",        "j375dap", 0x0C, 0x6002, "Mac Studio (M1 Ultra, 2022)" },
 	{ "Mac14,2",        "j413ap",  0x28, 0x8112, "MacBook Air (M2, 2022)" },
 	{ "Mac14,7",        "j493ap",  0x2A, 0x8112, "MacBook Pro (M2, 13-inch, 2022)" },
+	{ "Mac14,3",        "j473ap",  0x24, 0x8112, "Mac mini (M2, 2023)" },
+	{ "Mac14,12",       "j474sap", 0x02, 0x6020, "Mac mini (M2 Pro, 2023)" },
 	/* Apple Silicon VMs (supported by Virtualization.framework on macOS 12) */
 	{ "VirtualMac2,1",  "vma2macosap",  0x20, 0xFE00, "Apple Virtual Machine 1" },
 	/* Apple T2 Coprocessor */


### PR DESCRIPTION
Hi, this change is to add support for new M2 Mac mini and M2 Pro Mac mini in libirecovery package only.
It also requires some changes in idevicerestore package as well because M2 Pro Mac mini requires new PCON1, Firmware along with other updates from Apple. I have created the patch and tested on M2 Pro Mac mini. I might need couple of more days to refine the code and then will submit the changes. Thanks. 