### PR TITLE
Add identifiers for Macs announced at WWDC23

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -322,9 +322,13 @@ static struct irecv_device irecv_devices[] = {
 	{ "Mac14,3",        "j473ap",  0x24, 0x8112, "Mac mini (M2, 2023)" },
 	{ "Mac14,5",        "j414cap", 0x04, 0x6021, "MacBook Pro (14-inch, M2 Max, 2023)" },
 	{ "Mac14,6",        "j416cap", 0x06, 0x6021, "MacBook Pro (16-inch, M2 Max, 2023)" },
+        { "Mac14,8",        "j180dap", 0x08, 0x6022, "Mac Pro (2023)" },
 	{ "Mac14,9",        "j414sap", 0x04, 0x6020, "MacBook Pro (14-inch, M2 Pro, 2023)" },
 	{ "Mac14,10",       "j416sap", 0x06, 0x6020, "MacBook Pro (16-inch, M2 Pro, 2023)" },
 	{ "Mac14,12",       "j474sap", 0x02, 0x6020, "Mac mini (M2 Pro, 2023)" },
+	{ "Mac14,13",       "j475cap", 0x0A, 0x6021, "Mac Studio (M2 Max, 2023)" },
+	{ "Mac14,14",       "j475dap", 0x0A, 0x6022, "Mac Studio (M2 Ultra, 2023)" },
+	{ "Mac14,15",       "j415ap", 0x2E, 0x8112, "MacBook Air (M2, 15-inch, 2023)" },
 	/* Apple Silicon VMs (supported by Virtualization.framework on macOS 12) */
 	{ "VirtualMac2,1",  "vma2macosap",  0x20, 0xFE00, "Apple Virtual Machine 1" },
 	/* Apple T2 Coprocessor */

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -328,7 +328,7 @@ static struct irecv_device irecv_devices[] = {
 	{ "Mac14,12",       "j474sap", 0x02, 0x6020, "Mac mini (M2 Pro, 2023)" },
 	{ "Mac14,13",       "j475cap", 0x0A, 0x6021, "Mac Studio (M2 Max, 2023)" },
 	{ "Mac14,14",       "j475dap", 0x0A, 0x6022, "Mac Studio (M2 Ultra, 2023)" },
-	{ "Mac14,15",       "j415ap", 0x2E, 0x8112, "MacBook Air (M2, 15-inch, 2023)" },
+	{ "Mac14,15",       "j415ap",  0x2E, 0x8112, "MacBook Air (M2, 15-inch, 2023)" },
 	/* Apple Silicon VMs (supported by Virtualization.framework on macOS 12) */
 	{ "VirtualMac2,1",  "vma2macosap",  0x20, 0xFE00, "Apple Virtual Machine 1" },
 	/* Apple T2 Coprocessor */


### PR DESCRIPTION
Title. Adds support for:
- `Mac14,8`, or Mac Pro (2023)
- `Mac14,13`, or Mac Studio (M2 Max, 2023)
- `Mac14,14`, or Mac Studio (M2 Ultra, 2023)
- `Mac14,15`, or MacBook Air (M2, 15-inch, 2023)

Nothing too fancy outside of this, made sure to keep everything lined up for you as well 🙂