### PR TITLE
Add September 2023 Apple Devices

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -159,6 +159,10 @@ static struct irecv_device irecv_devices[] = {
 	{ "iPhone14,8",	 "d28ap",    0x1A, 0x8110, "iPhone 14 Plus" },
 	{ "iPhone15,2",	 "d73ap",    0x0C, 0x8120, "iPhone 14 Pro" },
 	{ "iPhone15,3",	 "d74ap",    0x0E, 0x8120, "iPhone 14 Pro Max" },
+	{ "iPhone15,4",	 "d37ap",    0x08, 0x8120, "iPhone 15" },
+	{ "iPhone15,5",	 "d38ap",    0x0A, 0x8120, "iPhone 15 Plus" },
+	{ "iPhone16,1",	 "d83ap",    0x04, 0x8130, "iPhone 15 Pro" },
+	{ "iPhone16,2",	 "d84ap",    0x06, 0x8130, "iPhone 15 Pro Max" },
 	/* iPod */
 	{ "iPod1,1",     "n45ap",    0x02, 0x8900, "iPod Touch (1st gen)" },
 	{ "iPod2,1",     "n72ap",    0x00, 0x8720, "iPod Touch (2nd gen)" },

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -308,6 +308,11 @@ static struct irecv_device irecv_devices[] = {
 	{ "Watch6,16",   "n198sap", 0x34, 0x8301, "Apple Watch Series 8 (41mm Cellular)" },
 	{ "Watch6,17",   "n198bap", 0x36, 0x8301, "Apple Watch Series 8 (45mm Cellular)" },
 	{ "Watch6,18",   "n199ap",  0x26, 0x8301, "Apple Watch Ultra" },
+	{ "Watch7,1",    "n207sap", 0x08, 0x8310, "Apple Watch Series 9 (41mm)" },
+	{ "Watch7,2",    "n207bap", 0x0A, 0x8310, "Apple Watch Series 9 (45mm)" },
+	{ "Watch7,3",    "n208sap", 0x0C, 0x8310, "Apple Watch Series 9 (41mm Cellular)" },
+	{ "Watch7,4",    "n208bap", 0x0E, 0x8310, "Apple Watch Series 9 (45mm Cellular)" },
+	{ "Watch7,5",    "n210ap",  0x02, 0x8310, "Apple Watch Ultra 2" },
 	/* Apple Silicon Macs */
 	{ "ADP3,2",         "j273aap", 0x42, 0x8027, "Developer Transition Kit (2020)" },
 	{ "Macmini9,1",	    "j274ap",  0x22, 0x8103, "Mac mini (M1, 2020)" },


### PR DESCRIPTION
Necessary for proper device support and for tsschecker.

New Devices:
* iPhone 15
* iPhone 15 Plus
* iPhone 15 Pro
* iPhone 15 Pro Max
* Apple Watch Series 9
* Apple Watch Ultra 2

you can squash and merge to make this as one commit.