### PR TITLE
Allow building "--without-tools" and fix "--with-dummy"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,11 +47,6 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_CHECK_FUNCS([strdup strerror strcasecmp strndup malloc realloc calloc])
 
-# Checks for libraries.
-AC_CHECK_HEADERS([readline/readline.h], [],
-	[AC_MSG_ERROR([Please install readline development headers])]
-)
-
 # Check additional platform flags
 AC_MSG_CHECKING([for platform-specific build settings])
 case ${host_os} in
@@ -99,6 +94,19 @@ AC_CACHE_CHECK([wether the C compiler supports constructor/destructor attributes
 if test "$ac_cv_attribute_constructor" = "yes"; then
   AC_DEFINE(HAVE_ATTRIBUTE_CONSTRUCTOR, 1, [Define if the C compiler supports constructor/destructor attributes])
 fi
+
+AC_ARG_WITH([tools],
+	[AS_HELP_STRING([--with-tools], [Build irecovery tools. (requires readline) [default=yes]])],
+	[],
+	[with_tools=yes])
+
+AS_IF([test "x$with_tools" = "xyes"], [
+	AC_DEFINE(BUILD_TOOLS, 1, [Define if we are building irecovery tools])
+	AC_CHECK_HEADERS([readline/readline.h], [],
+		[AC_MSG_ERROR([Please install readline development headers])]
+	)]
+)
+AM_CONDITIONAL(BUILD_TOOLS, test "x$with_tools" = "xyes")
 
 AC_ARG_WITH([dummy],
 	[AS_HELP_STRING([--with-dummy], [Use no USB driver at all [default=no]. This is only useful if you just want to query the device list by product type or hardware model. All other operations are no-ops or will return IRECV_E_UNSUPPORTED.])],

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -1048,6 +1048,7 @@ static int check_context(irecv_client_t client)
 }
 #endif
 
+#ifndef USE_DUMMY
 void irecv_init(void)
 {
 #ifndef USE_DUMMY
@@ -1062,7 +1063,6 @@ void irecv_exit(void)
 #endif
 }
 
-#ifndef USE_DUMMY
 #ifdef HAVE_IOKIT
 static int iokit_usb_control_transfer(irecv_client_t client, uint8_t bm_request_type, uint8_t b_request, uint16_t w_value, uint16_t w_index, unsigned char *data, uint16_t w_length, unsigned int timeout)
 {

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,3 +1,4 @@
+if BUILD_TOOLS
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 AM_CFLAGS = $(GLOBAL_CFLAGS) $(libusb_CFLAGS)
@@ -9,3 +10,4 @@ irecovery_SOURCES = irecovery.c
 irecovery_CFLAGS = $(AM_CFLAGS)
 irecovery_LDFLAGS = $(AM_LDFLAGS)
 irecovery_LDADD = $(top_builddir)/src/libirecovery-1.0.la
+endif


### PR DESCRIPTION
When building tsschecker and some other libs, it isn't necessary to build the libirecovery tools, which requires readline. so giving the option to skip building tools will help make it easier to compile tsschecker (and related tools).

this PR also fixes --with-dummy because for some reason it wasn't working correctly.
see this patch for more info: https://gist.github.com/1Conan/2d015aad17f87f171b32ebfd9f48fb96