### PR TITLE
MacOS Missing dependency in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ section of the README on how to build it. Note that some platforms might have it
 
   Using Homebrew:
   ```shell
-  brew install libtool autoconf automake pkg-config
+  brew install libtool autoconf automake pkg-config libimobiledevice-glue
   ```
 
 #### Windows


### PR DESCRIPTION
Added missing dependency for MacOS

Compiled on: MacBook Air M2