### PR TITLE
Add Private Cloud Compute Research Environment model

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -480,6 +480,8 @@ static struct irecv_device irecv_devices[] = {
 	/* Apple Vision Pro */
 	{ "RealityDevice14,1", "n301ap", 0x42, 0x8112, "Apple Vision Pro" },
 	{ "RealityDevice17,1", "n301aap", 0x42, 0x8142, "Apple Vision Pro (M5)" },
+	/* Private Cloud Compute Research Environment */
+	{ "iPhone99,11", "vresearch101ap", 0x90, 0xFE01, "iPhone 99,11" },
 	{ NULL,          NULL,         -1,     -1, NULL }
 };
 


### PR DESCRIPTION
## Summary

- Add device entry for Apple's Private Cloud Compute (PCC) Research Environment virtual machine (`iPhone99,11`, `vresearch101ap`, BDID `0x90`, CPID `0xFE01`)

This device appears when booting a PCC security research VM (platform version 3) into DFU mode via `Virtualization.framework`. Adding this entry allows `irecovery` and `idevicerestore` to correctly identify and interact with the virtual device.

Reference: https://security.apple.com/blog/pcc-security-research