### PR TITLE
Fix dummy and without tools build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,8 +90,8 @@ AS_IF([test "x$with_tools" = "xyes"], [
 		have_readline=yes],
 		[AC_MSG_NOTICE([NOTE: Building without readline support. If you want readline support, install its development package.])]
 	)
-	AM_CONDITIONAL(HAVE_READLINE, test "x$have_readline" = "xyes")
 ])
+AM_CONDITIONAL(HAVE_READLINE, test "x$have_readline" = "xyes")
 AM_CONDITIONAL(BUILD_TOOLS, test "x$with_tools" = "xyes")
 
 AC_ARG_WITH([dummy],

--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -104,7 +104,9 @@ struct irecv_async_transfer {
  #ifdef HAVE_IOKIT
  	kern_return_t ret;
  #else
+ #ifndef USE_DUMMY
  	enum libusb_transfer_status ret;
+ #endif
  #endif
 };
 
@@ -1533,6 +1535,7 @@ static int iokit_async_usb_control_transfer(irecv_client_t client, uint8_t bm_re
 }
 
 #else
+#ifndef USE_DUMMY
 
 static void async_cb(struct libusb_transfer* usb_transfer) {
 	struct irecv_async_transfer* transfer = usb_transfer->user_data;
@@ -1540,6 +1543,7 @@ static void async_cb(struct libusb_transfer* usb_transfer) {
 	transfer->len += usb_transfer->actual_length;
 }
 
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Fixes `error: conditional "HAVE_READLINE" was never defined.` on config and libusb usage on `--with-dummy`