### PR TITLE
fix: IOKit service lifetime during KIS retries [M5 2026 support]

### DIFF
--- a/src/libirecovery.c
+++ b/src/libirecovery.c
@@ -2705,9 +2705,9 @@ static void* _irecv_handle_device_add(void *userdata)
 	}
 
 	if (product_id == KIS_PRODUCT_ID) {
-		IOObjectRetain(device);
 		int i = 0;
 		for (i = 0; i < 10; i++) {
+			IOObjectRetain(device);
 			error = iokit_usb_open_service(&client, device);
 			if (error == IRECV_E_SUCCESS) {
 				break;


### PR DESCRIPTION
### The Issue

KIS discovery reused one retained reference across multiple open attempts. A retry could therefore release an invalid Mach port and cause macOS to terminate the process with `EXC_GUARD`.

### The Fix 

Retain the service separately for each open attempt while preserving the callback's iterator-owned reference.

### Not reproducible in happy path

The issue only arises during multiple retry attempts (which was the case during my debugging/fixing `idevicerecovery` on macOS 27 Beta (`deviceinterfaced` system daemon aggressively competes with it)